### PR TITLE
close #16 人口区分ごとの表示切り替えUIの実装

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -182,7 +182,6 @@ export default function Home() {
 
             {/* 人口推移グラフ */}
             <div className='mx-6 mt-12'>
-                {/* TODO: 年少人口、生産年齢人口、老年人口に切り替えるUIを実装） */}
                 <HighchartsReact highcharts={Highcharts} options={chartOptions} />
             </div>
         </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,6 +24,11 @@ export default function Home() {
     // エラーメッセージ表示用
     const [error, setError] = useState<string | null>(null);
 
+    // 表示する人口区分ラベル（総人口／年少人口／生産年齢人口／老年人口）
+    const [selectedPopulationClassLabel, setSelectedPopulationClassLabel] = useState<
+        '総人口' | '年少人口' | '生産年齢人口' | '老年人口'
+    >('総人口');
+
     // 都道府県コードをキーにして、都道府県名をMapで保存
     const prefectureMap = new Map(prefectures.map((p) => [p.prefCode, p.prefName]));
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -139,6 +139,23 @@ export default function Home() {
             {/* 都道府県一覧データの取得に失敗したときのエラーメッセージ */}
             {error && <p className='m-3 text-red-500'>エラー: {error}</p>}
 
+            {/* 人口区分切り替え用ラジオボタン */}
+            <div className='m-4 flex flex-wrap items-center justify-center gap-4'>
+                {(['総人口', '年少人口', '生産年齢人口', '老年人口'] as const).map(
+                    (label) => (
+                        <label key={label} className='flex items-center gap-1'>
+                            <input
+                                type='radio'
+                                value={label}
+                                checked={selectedPopulationClassLabel === label}
+                                onChange={() => setSelectedPopulationClassLabel(label)}
+                            />
+                            {label}
+                        </label>
+                    ),
+                )}
+            </div>
+
             {/* 都道府県のチェックボックスリスト */}
             <div className='mt-12 ml-18 grid grid-cols-2 gap-x-6 gap-y-4 sm:ml-24 sm:grid-cols-3 md:ml-24 md:grid-cols-4 lg:ml-20 lg:grid-cols-6'>
                 {prefectures.map((pref) => (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -104,6 +104,12 @@ export default function Home() {
         // Y軸のラベル
         yAxis: {
             title: { text: '人口数' },
+            labels: {
+                // カンマ区切り表示
+                formatter: function (this: Highcharts.AxisLabelsFormatterContextObject) {
+                    return this.value.toLocaleString();
+                },
+            },
         },
         // 各都道府県ごとの人口推移折れ線グラフの作成処理
         series: selectedPrefectures

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -88,32 +88,33 @@ export default function Home() {
     const chartOptions = {
         // グラフのタイトル
         title: {
-            text: '都道府県別 総人口の推移',
+            text: `都道府県別 ${selectedPopulationClassLabel} の推移`,
         },
         // X軸のラベル
         xAxis: {
             title: { text: '年度' },
-
-            // X軸の値（年度）を、全都道府県の中から「総人口」の年だけ集めて並べる
+            // 選択された人口区分に応じたX軸の目盛りを取得
             categories: [...populationDataMap.values()].flatMap(
                 (d) =>
-                    d.data.find((p) => p.label === '総人口')?.data.map((e) => e.year) ||
-                    [],
+                    d.data
+                        .find((p) => p.label === selectedPopulationClassLabel)
+                        ?.data.map((e) => e.year) || [],
             ),
         },
         // Y軸のラベル
         yAxis: {
             title: { text: '人口数' },
         },
+        // 各都道府県ごとの人口推移折れ線グラフの作成処理
         series: selectedPrefectures
             .map((prefCode) => {
                 const populationData = populationDataMap.get(prefCode);
                 // データがまだない場合はスキップ
                 if (!populationData) return null;
 
-                // 総人口のデータだけ抽出
+                // 選択された人口区分のデータだけ抽出
                 const totalPopulation = populationData.data.find(
-                    (d) => d.label === '総人口',
+                    (d) => d.label === selectedPopulationClassLabel,
                 );
                 if (!totalPopulation) return null;
 


### PR DESCRIPTION
## チェックリスト
- [x] vercelのビルドが通っている
- [x] ciが通っている(lint, format, test)
- [x] チケットの完了条件を満たしている

## 変更点
- 人口区分（総人口・年少人口など）を選択できるラジオボタンを実装

- 選択された人口区分に応じて、グラフのタイトル・目盛りを動的に変更

- Y軸の目盛りの値表示をカンマ区切りに変更

# 補足
- 次のタスクとして、ラジオボタンやグラフのコンポーネント化を行う